### PR TITLE
Added files to database + Removed BOM from several files

### DIFF
--- a/SE_cheats_db/PCSB00244.lua
+++ b/SE_cheats_db/PCSB00244.lua
@@ -1,7 +1,9 @@
 -- Jetpack Joyride (EUR)
 -- Credits: Slade
 
+
 needs_crc32 = true
+
 
 cur_chts = {
 	{["name"]="500,000 Credits", ["offset"]=0x50, ["file"]="JETPACK.SAV", ["value"]=0x7A120, ["size"]=4}

--- a/SE_cheats_db/PCSB00264.lua
+++ b/SE_cheats_db/PCSB00264.lua
@@ -1,4 +1,4 @@
-﻿-- Nun Attack (USA)
+﻿-- Nun Attack (EUR)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSB00264.lua
+++ b/SE_cheats_db/PCSB00264.lua
@@ -1,4 +1,4 @@
-﻿-- Nun Attack (EUR)
+-- Nun Attack (EUR)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSB00264.lua
+++ b/SE_cheats_db/PCSB00264.lua
@@ -1,4 +1,4 @@
-﻿-- Nun Attack (UNK)
+﻿-- Nun Attack (USA)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSB00264.lua
+++ b/SE_cheats_db/PCSB00264.lua
@@ -1,0 +1,12 @@
+﻿-- Nun Attack (UNK)
+-- Credits: Slade
+
+needs_crc32 = false
+
+cur_chts = {
+	{["name"]="9,999,999 Gold", ["offset"]=0x34, ["file"]="SAVEGAME_000.sav", ["value"]=0x98967F, ["size"]=4},
+	{["name"]="Max Level Eva", ["offset"]=0x78, ["file"]="SAVEGAME_000.sav", ["value"]=0xC350, ["size"]=4},
+	{["name"]="Max Level Rosy", ["offset"]=0xF4, ["file"]="SAVEGAME_000.sav", ["value"]=0xC350, ["size"]=4},
+	{["name"]="Max Level Olga", ["offset"]=0x170, ["file"]="SAVEGAME_000.sav", ["value"]=0xC350, ["size"]=4},
+	{["name"]="Max Level Mandy", ["offset"]=0x1EC, ["file"]="SAVEGAME_000.sav", ["value"]=0xC350, ["size"]=4}
+}

--- a/SE_cheats_db/PCSE00291.lua
+++ b/SE_cheats_db/PCSE00291.lua
@@ -1,4 +1,4 @@
-﻿-- Crazy Market (USA)
+-- Crazy Market (USA)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSE00291.lua
+++ b/SE_cheats_db/PCSE00291.lua
@@ -5,5 +5,5 @@ needs_crc32 = false
 
 cur_chts = {
 	{["name"]="99 Coffee", ["offset"]=0x520, ["file"]="data.bin", ["value"]=0x63, ["size"]=1},
-	{["name"]="99,999,999 Coins", ["offset"]=0x524, ["file"]="data.bin", ["value"]=0x5F5E0FF, ["size"]=4},
+	{["name"]="99,999,999 Coins", ["offset"]=0x524, ["file"]="data.bin", ["value"]=0x5F5E0FF, ["size"]=4}
 }

--- a/SE_cheats_db/PCSE00291.lua
+++ b/SE_cheats_db/PCSE00291.lua
@@ -1,4 +1,4 @@
-﻿-- Crazy Market (EUR)
+﻿-- Crazy Market (USA)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSE00291.lua
+++ b/SE_cheats_db/PCSE00291.lua
@@ -1,0 +1,9 @@
+﻿-- Crazy Market (UNK)
+-- Credits: Slade
+
+needs_crc32 = false
+
+cur_chts = {
+	{["name"]="99 Coffee", ["offset"]=0x520, ["file"]="data.bin", ["value"]=0x63, ["size"]=1},
+	{["name"]="99,999,999 Coins", ["offset"]=0x524, ["file"]="data.bin", ["value"]=0x5F5E0FF, ["size"]=4},
+}

--- a/SE_cheats_db/PCSE00291.lua
+++ b/SE_cheats_db/PCSE00291.lua
@@ -1,4 +1,4 @@
-﻿-- Crazy Market (UNK)
+﻿-- Crazy Market (EUR)
 -- Credits: Slade
 
 needs_crc32 = false

--- a/SE_cheats_db/PCSE00388.lua
+++ b/SE_cheats_db/PCSE00388.lua
@@ -1,0 +1,16 @@
+-- Titan Attacks (USA)
+-- Credits: Slade
+
+needs_crc32 = false
+
+cur_chts = {
+	{["name"]="Max Shields", ["offset"]=0x1A, ["file"]="data_0.bin", ["value"]=0x08, ["size"]=1},
+	{["name"]="Max Gun Power", ["offset"]=0x1B, ["file"]="data_0.bin", ["value"]=0x08, ["size"]=1},
+	{["name"]="Max Smart Bomb", ["offset"]=0x1D, ["file"]="data_0.bin", ["value"]=0x03, ["size"]=1},
+	{["name"]="Max Add-ons", ["offset"]=0x1E, ["file"]="data_0.bin", ["value"]=0x04, ["size"]=1},
+	{["name"]="Max Recharge", ["offset"]=0x1F, ["file"]="data_0.bin", ["value"]=0x04, ["size"]=1},
+	{["name"]="Max Xtra Bullets", ["offset"]=0x1C, ["file"]="data_0.bin", ["value"]=0x05, ["size"]=1},
+	{["name"]="99,999 Cash", ["offset"]=0x10, ["file"]="data_0.bin", ["value"]=0x1869F, ["size"]=4},
+	{["name"]="Max Bonus", ["offset"]=0x19, ["file"]="data_0.bin", ["value"]=0x63, ["size"]=1},
+	{["name"]="Max Smarts", ["offset"]=0x18, ["file"]="data_0.bin", ["value"]=0x03, ["size"]=1}
+}

--- a/SE_cheats_db/PCSE00666.lua
+++ b/SE_cheats_db/PCSE00666.lua
@@ -1,0 +1,14 @@
+﻿-- Heroes of Loot (UNK)
+-- Credits: Slade
+
+needs_crc32 = false
+
+cur_chts = {
+	{["name"]="99,999 Gold", ["offset"]=0x6B, ["file"]="SaveGave.sav", ["value"]=0x1869F, ["size"]=4},
+	{["name"]="5 Keys", ["offset"]=0x7B, ["file"]="SaveGave.sav", ["value"]=0x5, ["size"]=1},
+	{["name"]="999 Max Health", ["offset"]=0x8B, ["file"]="SaveGave.sav", ["value"]=0x3E7, ["size"]=4},
+	{["name"]="999 Health", ["offset"]=0x77, ["file"]="SaveGave.sav", ["value"]=0x3E7, ["size"]=4},
+	{["name"]="Max Level", ["offset"]=0x87, ["file"]="SaveGave.sav", ["value"]=0x14, ["size"]=1},
+	{["name"]="Max Score", ["offset"]=0x9F, ["file"]="SaveGave.sav", ["value"]=0xF423F, ["size"]=4},
+	{["name"]="Dungeon 29", ["offset"]=0x49, ["file"]="SaveGave.sav", ["value"]=0x1D, ["size"]=4},
+}

--- a/SE_cheats_db/PCSE00666.lua
+++ b/SE_cheats_db/PCSE00666.lua
@@ -1,4 +1,4 @@
-﻿-- Heroes of Loot (UNK)
+-- Heroes of Loot (USA)
 -- Credits: Slade
 
 needs_crc32 = false
@@ -10,5 +10,5 @@ cur_chts = {
 	{["name"]="999 Health", ["offset"]=0x77, ["file"]="SaveGave.sav", ["value"]=0x3E7, ["size"]=4},
 	{["name"]="Max Level", ["offset"]=0x87, ["file"]="SaveGave.sav", ["value"]=0x14, ["size"]=1},
 	{["name"]="Max Score", ["offset"]=0x9F, ["file"]="SaveGave.sav", ["value"]=0xF423F, ["size"]=4},
-	{["name"]="Dungeon 29", ["offset"]=0x49, ["file"]="SaveGave.sav", ["value"]=0x1D, ["size"]=4},
+	{["name"]="Dungeon 29", ["offset"]=0x49, ["file"]="SaveGave.sav", ["value"]=0x1D, ["size"]=4}
 }

--- a/SE_cheats_db/PCSE00786.lua
+++ b/SE_cheats_db/PCSE00786.lua
@@ -1,4 +1,4 @@
--- Legend of Heroes: Trails of Cold Steel (USA)
+﻿-- Legend of Heroes: Trails of Cold Steel (USA)
 -- Credits: currowth
 
 needs_crc32 = false
@@ -13,5 +13,5 @@ cur_chts = {
 	{["name"]="x9999999 Black Sepith", ["offset"]=0x65C78, ["file"]="save000.dat", ["value"]=0x98967F, ["size"]=4},
 	{["name"]="x9999999 Yellow Sepith", ["offset"]=0x65C7C, ["file"]="save000.dat", ["value"]=0x98967F, ["size"]=4},
 	{["name"]="x9999999 White Sepith", ["offset"]=0x65C80, ["file"]="save000.dat", ["value"]=0x98967F, ["size"]=4},
-	{["name"]="x99 U-Material", ["offset"]=0x4165A, ["file"]="save000.dat", ["value"]=0x63, ["size"]=2}
-} 
+	{["name"]="x99 U-Material", ["offset"]=0x4165A, ["file"]="save000.dat", ["value"]=0x63, ["size"]=2},
+}

--- a/SE_cheats_db/PCSF00427.lua
+++ b/SE_cheats_db/PCSF00427.lua
@@ -1,8 +1,7 @@
--- Dead Nation (GLOBAL)
+﻿-- Dead Nation (ALL)
 -- Credits: Slade
 
 needs_crc32 = false
-
 
 cur_chts = {
 	{["name"]="9,999,999 Cash", ["offset"]=0x6A47, ["file"]="SAVE.DAT", ["value"]=0x98967F, ["size"]=4},
@@ -54,5 +53,5 @@ cur_chts = {
 	{["name"]="Auto-Turret Unlock (No purchase)", ["offset"]=0x6C07, ["file"]="SAVE.DAT", ["value"]=0x03, ["size"]=1},
 	{["name"]="Auto-Turret Purchasable", ["offset"]=0x6C13, ["file"]="SAVE.DAT", ["value"]=0x0303, ["size"]=4},
 	{["name"]="Auto-Turret Max Level", ["offset"]=0x6C0B, ["file"]="SAVE.DAT", ["value"]=0x0303, ["size"]=4},
-	{["name"]="Auto-Turret Infinite Ammo", ["offset"]=0x6C1D, ["file"]="SAVE.DAT", ["value"]=0xFFFF, ["size"]=4}
+	{["name"]="Auto-Turret Infinite Ammo", ["offset"]=0x6C1D, ["file"]="SAVE.DAT", ["value"]=0xFFFF, ["size"]=4},
 }


### PR DESCRIPTION
The Byte Order Mark is not visible in Notepad nor the edit field on GitHub. The files appear identical, however will fail when loaded into rinCheat CE. Several files have had the BOM removed from them, and the editor code updated to remove it from all newly created files.
